### PR TITLE
java.sql.BatchUpdateException: Data truncation: Data too long for column 'email' at row 1

### DIFF
--- a/src/main/java/net/easymodo/asagi/SQL.java
+++ b/src/main/java/net/easymodo/asagi/SQL.java
@@ -82,7 +82,7 @@ public abstract class SQL implements DB {
 
         if(this.insertQuery == null) {
             this.insertQuery = String.format(
-                    "INSERT INTO %s" +
+                    "INSERT IGNORE INTO %s" +
                     " (poster_ip, num, subnum, thread_num, op, timestamp, timestamp_expired, preview_orig, preview_w, preview_h, media_filename, " +
                     " media_w, media_h, media_size, media_hash, media_orig, spoiler, deleted, " +
                     " capcode, email, name, trip, title, comment, delpass, sticky, poster_hash, poster_country, exif) " +


### PR DESCRIPTION
Forces MySQL INSERT to continue with warnings instead of aborting full query statement.

This forces asagi to continue processing the SQL batch statement without aborting the entire statement. The change to `INSERT IGNORE INTO` will cause the statement to truncate the data and continue inserting everything. It would resolve the issue of missing posts due to the following error: `Couldn't insert topic ########: java.sql.BatchUpdateException: Data truncation: Data too long for column 'email' at row 1`
